### PR TITLE
Enhance SPDX output to appease parsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 target/
 .cache/
 
-default.profraw
 public
+*.profraw

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,10 +114,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -165,6 +180,7 @@ name = "cargo-sbom"
 version = "0.9.1"
 dependencies = [
  "anyhow",
+ "base16ct",
  "built",
  "cargo_metadata",
  "chrono",
@@ -178,6 +194,7 @@ dependencies = [
  "serde-cyclonedx",
  "serde-spdx",
  "serde_json",
+ "sha1",
  "spdx",
  "uuid",
  "whoami",
@@ -286,6 +303,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +400,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +474,16 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -520,9 +576,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "log"
@@ -799,6 +855,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shared_child"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,6 +965,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +1000,12 @@ checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/cargo-sbom/Cargo.toml
+++ b/cargo-sbom/Cargo.toml
@@ -1,11 +1,51 @@
-[workspace]
-members = [
-  "cargo-sbom",
-  "serde-spdx",
-  "serde-cyclonedx",
-  "tests",
-]
-resolver = "2"
+[package]
+name = "cargo-sbom"
+version = "0.9.1"
+edition = "2021"
+description = "Create software bill of materials (SBOM) for Rust"
+license = "MIT"
+readme = "README.md"
+authors = ["Paul Sastrasinh <psastras@gmail.com>"]
+keywords = ["sbom", "spdx", "cyclonedx", "cli", "terminal"]
+categories = ["command-line-utilities"]
+homepage = "https://github.com/psastras/sbom-rs"
+documentation = "https://docs.rs/cargo_sbom"
+repository = "https://github.com/psastras/sbom-rs"
 
-[profile.release]
-strip = true
+[dependencies]
+anyhow = "1.0.98"
+cargo_metadata = "0.18.1"
+chrono = "0.4.38"
+clap = { version = "4.5.13", features = ["derive", "string"] }
+clap-cargo = "0.15.2"
+packageurl = "0.4.0"
+petgraph = "0.6.5"
+semver = "1.0.23"
+serde-cyclonedx = { path = "../serde-cyclonedx", version = "0.9.1" }
+serde-spdx = { path = "../serde-spdx", version = "0.9.1" }
+serde_json = "1.0.120"
+spdx = "0.10.6"
+whoami = "1.6.0"
+sha1 = "0.10.6"
+base16ct = { version = "0.2.0", features = ["alloc"] }
+
+[[bin]]
+name = "cargo-sbom"
+path = "src/main.rs"
+
+[build-dependencies]
+built = "0.7"
+
+[dependencies.uuid]
+version = "1.16.0"
+features = [
+    "v4", # Lets you generate random UUIDs
+]
+
+[dev-dependencies]
+duct = "0.13.7"
+duct_sh = "0.13.7"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }"
+pkg-fmt = "bin"

--- a/cargo-sbom/Cargo.toml
+++ b/cargo-sbom/Cargo.toml
@@ -26,6 +26,8 @@ serde-spdx = { path = "../serde-spdx", version = "0.9.1" }
 serde_json = "1.0.120"
 spdx = "0.10.6"
 whoami = "1.5.1"
+sha1 = "0.10.6"
+base16ct = { version = "0.2.0", features = ["alloc"] }
 
 [[bin]]
 name = "cargo-sbom"

--- a/cargo-sbom/src/main.rs
+++ b/cargo-sbom/src/main.rs
@@ -246,7 +246,7 @@ fn try_main() -> Result<()> {
 
   if !cargo_manifest_path.exists() {
     return Err(anyhow!(
-      "Cargo manfiest (Cargo.toml) does not exist in the supplied directory ({}).",
+      "Cargo manifest (Cargo.toml) does not exist in the supplied directory ({}).",
       opt.project_directory.canonicalize()?.to_string_lossy()
     ));
   }

--- a/cargo-sbom/src/main.rs
+++ b/cargo-sbom/src/main.rs
@@ -270,8 +270,12 @@ fn try_main() -> Result<()> {
       serde_json::to_string_pretty(&cyclonedx)?
     )?;
   } else if matches!(opt.output_format, OutputFormat::SpdxJson_2_3) {
-    let spdx =
-      util::spdx::convert(opt.cargo_package, &opt.project_directory, &graph)?;
+    let spdx = util::spdx::convert(
+      opt.cargo_package,
+      &opt.project_directory,
+      &cargo_manifest_path,
+      &graph,
+    )?;
     writeln!(
       std::io::stdout(),
       "{}",

--- a/cargo-sbom/src/main.rs
+++ b/cargo-sbom/src/main.rs
@@ -252,7 +252,7 @@ fn try_main() -> Result<()> {
   }
 
   let metadata = MetadataCommand::new()
-    .manifest_path(cargo_manifest_path)
+    .manifest_path(&cargo_manifest_path)
     .features(CargoOpt::AllFeatures)
     .exec()?;
 
@@ -271,7 +271,7 @@ fn try_main() -> Result<()> {
     )?;
   } else if matches!(opt.output_format, OutputFormat::SpdxJson_2_3) {
     let spdx =
-      util::spdx::convert(opt.cargo_package, opt.project_directory, &graph)?;
+      util::spdx::convert(opt.cargo_package, &opt.project_directory, &graph)?;
     writeln!(
       std::io::stdout(),
       "{}",

--- a/cargo-sbom/src/util/spdx/license.rs
+++ b/cargo-sbom/src/util/spdx/license.rs
@@ -1,10 +1,14 @@
 use anyhow::{anyhow, Ok, Result};
 
-pub fn normalize_license_string<S: AsRef<str>>(
+pub fn normalize_license_string<S: AsRef<str> + ToString>(
   rust_license_string: S,
 ) -> Result<String> {
+  let quotes: &[_] = &['"', '\''];
   let license_expr = spdx::Expression::parse_mode(
-    rust_license_string.as_ref(),
+    rust_license_string
+      .as_ref()
+      .trim_start_matches(quotes)
+      .trim_end_matches(quotes),
     spdx::ParseMode::LAX,
   )?;
 
@@ -99,6 +103,19 @@ pub fn normalize_license_string<S: AsRef<str>>(
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  #[test]
+  fn test_quotation() {
+    assert_eq!(
+      normalize_license_string("'MIT OR Apache-2.0'").unwrap(),
+      "MIT OR Apache-2.0"
+    );
+
+    assert_eq!(
+      normalize_license_string("\"MIT OR Apache-2.0\"").unwrap(),
+      "MIT OR Apache-2.0"
+    );
+  }
 
   #[test]
   fn test_or() {

--- a/cargo-sbom/src/util/spdx/license.rs
+++ b/cargo-sbom/src/util/spdx/license.rs
@@ -108,7 +108,7 @@ mod tests {
     );
 
     assert_eq!(
-      normalize_license_string("MIT / Apache-2.0").unwrap(),
+      normalize_license_string("MIT/Apache-2.0").unwrap(),
       "MIT OR Apache-2.0"
     );
 

--- a/cargo-sbom/src/util/spdx/mod.rs
+++ b/cargo-sbom/src/util/spdx/mod.rs
@@ -55,11 +55,7 @@ pub fn convert(
 ) -> Result<serde_spdx::spdx::v_2_3::Spdx> {
   let creation_info =
     serde_spdx::spdx::v_2_3::SpdxCreationInfoBuilder::default()
-      .created(
-        chrono::Utc::now()
-          .format("%Y-%m-%dT%H:%M:%SZ")
-          .to_string(),
-      )
+      .created(chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string())
       .creators(vec![format!(
         "Tool: {}-v{}",
         built_info::PKG_NAME,

--- a/cargo-sbom/src/util/spdx/mod.rs
+++ b/cargo-sbom/src/util/spdx/mod.rs
@@ -1,10 +1,14 @@
 pub mod license;
-use std::{collections::HashSet, path::Path};
+use std::{
+  collections::HashSet,
+  path::{Path, PathBuf},
+};
 
 use crate::graph::Graph;
 use anyhow::{anyhow, Ok, Result};
 use cargo_metadata::Package;
 use petgraph::visit::EdgeRef;
+use sha1::{Digest, Sha1};
 
 pub mod built_info {
   // The file has been placed there by the build script.
@@ -49,6 +53,42 @@ impl std::cmp::PartialEq for HashableSpdxItemRelationships {
 
 impl std::cmp::Eq for HashableSpdxItemRelationships {}
 
+/// All the data we use comes from the lock file, so we treat that
+/// as the root file of the package so we have something to checksum.
+fn process_root_file(
+  spdx_id: &str,
+  project_directory: &Path,
+  cargo_manifest_path: &Path,
+) -> Result<serde_spdx::spdx::v_2_3::SpdxItemFiles> {
+  let lockfile = cargo_manifest_path.canonicalize()?.with_extension("lock");
+  let contents = std::fs::read(&lockfile)?;
+  let checksum = Sha1::digest(&contents);
+
+  // SHA1 only algorithm supported
+  let checksum_element =
+    serde_spdx::spdx::v_2_3::SpdxItemFilesItemChecksumsBuilder::default()
+      .algorithm("SHA1")
+      .checksum_value(base16ct::lower::encode_string(&checksum))
+      .build()
+      .unwrap();
+
+  let relative_lockfile = PathBuf::from(&".")
+    .join(lockfile.strip_prefix(project_directory.canonicalize()?)?);
+  let relative_lockfile_string = relative_lockfile
+    .to_str()
+    .ok_or_else(|| anyhow!(&"Non-UTF8 relative lockfile path"))?;
+
+  std::result::Result::Ok(
+    serde_spdx::spdx::v_2_3::SpdxItemFilesBuilder::default()
+      .spdxid(spdx_id)
+      .file_name(relative_lockfile_string)
+      .checksums(vec![checksum_element])
+      .file_types(vec!["SOURCE".to_string(), "TEXT".to_string()])
+      .build()
+      .unwrap(),
+  )
+}
+
 /// Generate SPDXRef-Package-... and replace characters that are common but not permitted
 fn generate_project_id(package: &Package) -> String {
   // underscores become two dashes to avoid collisions with similarly named packages
@@ -60,6 +100,7 @@ fn generate_project_id(package: &Package) -> String {
 pub fn convert(
   cargo_package: Option<String>,
   project_directory: &Path,
+  cargo_manifest_path: &Path,
   graph: &Graph,
 ) -> Result<serde_spdx::spdx::v_2_3::Spdx> {
   let creation_info =
@@ -170,18 +211,15 @@ pub fn convert(
       .iter()
       .filter(|target| target.is_bin() || target.is_lib())
       .for_each(|target| {
+        let spdx_id = format!("SPDXRef-File-{}", target.name);
+
         files.push(
-          serde_spdx::spdx::v_2_3::SpdxItemFilesBuilder::default()
-            .spdxid(format!("SPDXRef-File-{}", target.name))
-            .checksums(vec![])
-            .file_name(&target.name)
-            .file_types(vec!["BINARY".to_string()])
-            .build()
+          process_root_file(&spdx_id, project_directory, cargo_manifest_path)
             .unwrap(),
         );
         relationships.insert(HashableSpdxItemRelationships(
           serde_spdx::spdx::v_2_3::SpdxItemRelationshipsBuilder::default()
-            .spdx_element_id(format!("SPDXRef-File-{}", target.name))
+            .spdx_element_id(&spdx_id)
             .related_spdx_element(generate_project_id(root))
             .relationship_type("GENERATED_FROM")
             .build()

--- a/cargo-sbom/src/util/spdx/mod.rs
+++ b/cargo-sbom/src/util/spdx/mod.rs
@@ -57,7 +57,7 @@ pub fn convert(
     serde_spdx::spdx::v_2_3::SpdxCreationInfoBuilder::default()
       .created(
         chrono::Utc::now()
-          .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+          .format("%Y-%m-%dT%H:%M:%SZ")
           .to_string(),
       )
       .creators(vec![format!(

--- a/cargo-sbom/src/util/spdx/mod.rs
+++ b/cargo-sbom/src/util/spdx/mod.rs
@@ -225,6 +225,15 @@ pub fn convert(
             .build()
             .unwrap(),
         ));
+
+        relationships.insert(HashableSpdxItemRelationships(
+          serde_spdx::spdx::v_2_3::SpdxItemRelationshipsBuilder::default()
+            .spdx_element_id("SPDXRef-DOCUMENT")
+            .related_spdx_element(&spdx_id)
+            .relationship_type("DESCRIBES")
+            .build()
+            .unwrap(),
+        ));
       });
   }
 

--- a/cargo-sbom/src/util/spdx/mod.rs
+++ b/cargo-sbom/src/util/spdx/mod.rs
@@ -1,5 +1,5 @@
 pub mod license;
-use std::{collections::HashSet, path::PathBuf};
+use std::{collections::HashSet, path::Path};
 
 use crate::graph::Graph;
 use anyhow::{anyhow, Ok, Result};
@@ -50,7 +50,7 @@ impl std::cmp::Eq for HashableSpdxItemRelationships {}
 
 pub fn convert(
   cargo_package: Option<String>,
-  project_directory: PathBuf,
+  project_directory: &Path,
   graph: &Graph,
 ) -> Result<serde_spdx::spdx::v_2_3::Spdx> {
   let creation_info =

--- a/serde-cyclonedx/src/lib.rs
+++ b/serde-cyclonedx/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/serde-cyclonedx/0.9.1")]
+#![allow(clippy::doc_lazy_continuation)]
 
 //! # serde-cyclonedx
 //!

--- a/serde-spdx/src/lib.rs
+++ b/serde-spdx/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/serde-spdx/0.9.1")]
+#![allow(clippy::doc_lazy_continuation)]
 
 //! # serde-spdx
 //!


### PR DESCRIPTION
I have some stuff that works mainly on tag-value files, so I wanted to convert the output. But, the output did not validate, especially not with pyspdxtools. So, I took quite a few steps to make it validate. Cherry-pick commits if you like. Hopefully I got the commit message format right. Every commit builds.

I did still have to manually remove "registry+" from the download location but I think that's an error in pyspdxtools:

```
package download_location must be a valid URL or download location according to the specification, but is: registry+https://github.com/rust-lang/crates.io-index
```

I will note that serde-cyclonedx/src/lib.rs has some test failures but I didn't touch anything over there, presumably bitrot.